### PR TITLE
Don't close if the handler returned an error

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -120,8 +120,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 			tw:                    transform.NewWriter(w, tr),
 			handler:               h,
 		}
-		defer fw.tw.Close()
-		return next.ServeHTTP(fw, r)
+		err := next.ServeHTTP(fw, r)
+		if err != nil {
+			return err
+		}
+		fw.tw.Close()
+		return nil
 	}
 
 	// get a buffer to hold the response body

--- a/handler.go
+++ b/handler.go
@@ -124,6 +124,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 		if err != nil {
 			return err
 		}
+		// only close if there is no error; see PR #21
+		// at time of writing, Close() only flushes remaining bytes, but
+		// this ends up calling WriteHeader() even if we don't want that
 		fw.tw.Close()
 		return nil
 	}

--- a/handler.go
+++ b/handler.go
@@ -125,7 +125,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 			return err
 		}
 		// only close if there is no error; see PR #21
-		// at time of writing, Close() only flushes remaining bytes, but
+		// as of May 2023, Close() only flushes remaining bytes, but
 		// this ends up calling WriteHeader() even if we don't want that
 		fw.tw.Close()
 		return nil


### PR DESCRIPTION
https://caddy.community/t/replace-response-returns-200-when-bad-gateway/19896

If an error happens during a handler that follows `replace` when stream mode is turned on, it causes status 200 to be written instead of the correct error status, and we see this warning in the logs (which comes from stdlib):

```
2023/05/12 12:34:38.281	DEBUG	http.stdlib	http: superfluous response.WriteHeader call from github.com/caddyserver/caddy/v2/modules/caddyhttp.StaticResponse.ServeHTTP (staticresp.go:243)
```

The problem happens because of the `Close()` call it seems. If we skip closing on errors, it fixes it.

But I don't know if this is the correct fix, because I'm not totally sure why closing writes a 200 in the first place. And I'm not sure if it would have side effects if we don't close, is anything left dangling? What if a response is partially written and the error happens in the middle of writing the body, would not closing harm that case? I'm not sure what happens to the status code if we error writing half way through the body, I guess it's already written out and it's too late?

Easy to replicate with a config like this:

```
:8881 {
	replace stream {
		"foo" "bar"
	}
	error "nah" 502
}
```

Making a request returns status 200, but status 502 is expected.